### PR TITLE
Release 0.0.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,12 @@
+## Version 0.0.2, 2017.10.05
+
+* Switch from `rpio` to `onoff`
+* Use `exit-hook` for better cleanup
+* Fix export for `NUM_PIXELS`
+* Fix bugs in code
+* Fix bugs in examples
+* Add more examples
+
+## Version 0.0.1, 2017.06.21
+
+* Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blinkt",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Module for interacting with the Raspberry Pi Blinkt! addon",
   "homepage": "https://github.com/NotNinja/node-blinkt",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "exit-hook": "^1.1.1",
-    "onoff": "^1.1.3"
+    "onoff": "^1.1.7"
   },
   "main": "src/blinkt.js"
 }


### PR DESCRIPTION
- [x] Switch from `rpio` to `onoff`
- [x] Use `exit-hook` for better cleanup
- [x] Fix export for `NUM_PIXELS`
- [x] Fix bugs in code
- [x] Fix bugs in examples
- [x] Add more examples